### PR TITLE
Add ipython to setup.py dependencies list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ dependencies = [
     "pandas",
     "nltk",
     "spacy",
-    "jellyfish"
+    "jellyfish",
+    "ipython"
 ]
 
 setuptools.setup(


### PR DESCRIPTION
#### Changes

Adds `IPython` to `setup.py`'s dependencies list.

#### Testing

1. Create and activate a new python virtual environment
2. Check out this branch and install it into the virtual environment.
```
git checkout defect/missing-requirements
python -m pip install .
python -m spacy download en_core_web_lg
```
3. Verify you can import SkillExtractor: `>>> from skillNer.skill_extractor_class import SkillExtractor`


Closes #51

